### PR TITLE
Add non-failing getter for params.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,10 @@ impl Params {
     pub fn insert(&mut self, key: String, value: String) {
         self.map.insert(key, value);
     }
+
+    pub fn find<'a>(&'a self, key: &str) -> Option<&'a str> {
+        self.map.find_with(|k| key.cmp(&k.as_slice())).map(|s| s.as_slice())
+    }
 }
 
 impl Index<&'static str, String> for Params {


### PR DESCRIPTION
Title says it all. Right now Index is the only way to get a value out of Params, which
will fail if the key is not present.

While I understand the motivation behind this - you should only be accessing params
that come from the url it limits certain useful patterns, like the ability to decode
params to use Decodable and convert Params to a struct.
