### PR TITLE
Handle 0-length paths and routes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,20 @@ fn root_router() {
 }
 
 #[test]
+fn empty_path() {
+  let mut router = Router::new();
+  router.add("/", 12i);
+  assert_eq!(*router.recognize("").unwrap().handler, 12)
+}
+
+#[test]
+fn empty_route() {
+  let mut router = Router::new();
+  router.add("", 12i);
+  assert_eq!(*router.recognize("/").unwrap().handler, 12)
+}
+
+#[test]
 fn ambiguous_router() {
     let mut router = Router::new();
 


### PR DESCRIPTION
Right now passing "" as a route or path causes task failure because of the check for `route.char_at(0)`. This causes "" to behave like "/", a sane default, instead.
