### PR TITLE
Two spaces -> Four spaces

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,302 +8,301 @@ pub mod nfa;
 
 #[deriving(Clone)]
 struct Metadata {
-  statics: int,
-  dynamics: int,
-  stars: int,
-  param_names: Vec<String>,
+    statics: int,
+    dynamics: int,
+    stars: int,
+    param_names: Vec<String>,
 }
 
 impl Metadata {
-  pub fn new() -> Metadata {
-    Metadata{ statics: 0, dynamics: 0, stars: 0, param_names: Vec::new() }
-  }
+    pub fn new() -> Metadata {
+        Metadata{ statics: 0, dynamics: 0, stars: 0, param_names: Vec::new() }
+    }
 }
 
 impl Ord for Metadata {
-  fn cmp(&self, other: &Metadata) -> Ordering {
-    if self.stars > other.stars {
-      Less
-    } else if self.stars < other.stars {
-      Greater
-    } else if self.dynamics > other.dynamics {
-      Less
-    } else if self.dynamics < other.dynamics {
-      Greater
-    } else if self.statics > other.statics {
-      Less
-    } else if self.statics < other.statics {
-      Greater
-    } else {
-      Equal
+    fn cmp(&self, other: &Metadata) -> Ordering {
+        if self.stars > other.stars {
+            Less
+        } else if self.stars < other.stars {
+            Greater
+        } else if self.dynamics > other.dynamics {
+            Less
+        } else if self.dynamics < other.dynamics {
+            Greater
+        } else if self.statics > other.statics {
+            Less
+        } else if self.statics < other.statics {
+            Greater
+        } else {
+            Equal
+        }
     }
-  }
 }
 
 impl PartialOrd for Metadata {
-  fn partial_cmp(&self, other: &Metadata) -> Option<Ordering> {
-    Some(self.cmp(other))
-  }
+    fn partial_cmp(&self, other: &Metadata) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl PartialEq for Metadata {
-  fn eq(&self, other: &Metadata) -> bool {
-    self.statics == other.statics && self.dynamics == other.dynamics && self.stars == other.stars
-  }
+    fn eq(&self, other: &Metadata) -> bool {
+        self.statics == other.statics && self.dynamics == other.dynamics && self.stars == other.stars
+    }
 }
 
 impl Eq for Metadata {}
 
 #[deriving(PartialEq, Clone, Show)]
 pub struct Params {
-  map: TreeMap<String, String>
+    map: TreeMap<String, String>
 }
 
 impl Params {
-  pub fn new() -> Params {
-    Params{ map: TreeMap::new() }
-  }
+    pub fn new() -> Params {
+        Params{ map: TreeMap::new() }
+    }
 
-  pub fn insert(&mut self, key: String, value: String) {
-    self.map.insert(key, value);
-  }
+    pub fn insert(&mut self, key: String, value: String) {
+        self.map.insert(key, value);
+    }
 }
 
 impl Index<&'static str, String> for Params {
-  fn index<'a>(&'a self, index: &&'static str) -> &'a String {
-    match self.map.find(&index.to_string()) {
-      None => fail!(format!("params[{}] did not exist", index)),
-      Some(s) => s,
+    fn index<'a>(&'a self, index: &&'static str) -> &'a String {
+        match self.map.find(&index.to_string()) {
+            None => fail!(format!("params[{}] did not exist", index)),
+            Some(s) => s,
+        }
     }
-  }
 }
 
 pub struct Match<T> {
-  pub handler: T,
-  pub params: Params
+    pub handler: T,
+    pub params: Params
 }
 
 impl<T> Match<T> {
-  pub fn new(handler: T, params: Params) -> Match<T> {
-    Match{ handler: handler, params: params }
-  }
+    pub fn new(handler: T, params: Params) -> Match<T> {
+        Match{ handler: handler, params: params }
+    }
 }
 
 #[deriving(Clone)]
 pub struct Router<T> {
-  nfa: NFA<Metadata>,
-  handlers: TreeMap<uint, T>
+    nfa: NFA<Metadata>,
+    handlers: TreeMap<uint, T>
 }
 
 impl<T> Router<T> {
-  pub fn new() -> Router<T> {
-    Router{ nfa: NFA::new(), handlers: TreeMap::new() }
-  }
-
-  pub fn add(&mut self, mut route: &str, dest: T) {
-    if route.char_at(0) == '/' {
-      route = route.slice_from(1);
+    pub fn new() -> Router<T> {
+        Router{ nfa: NFA::new(), handlers: TreeMap::new() }
     }
 
-    let nfa = &mut self.nfa;
-    let mut state = 0;
-    let mut metadata = Metadata::new();
-
-    for (i, segment) in route.split('/').enumerate() {
-      if i > 0 { state = nfa.put(state, CharacterClass::valid_char('/')); }
-
-      if segment.len() > 0 && segment.char_at(0) == ':' {
-        state = process_dynamic_segment(nfa, state);
-        metadata.dynamics += 1;
-        metadata.param_names.push(segment.slice_from(1).to_string());
-      } else if segment.len() > 0 && segment.char_at(0) == '*' {
-        state = process_star_state(nfa, state);
-        metadata.stars += 1;
-        metadata.param_names.push(segment.slice_from(1).to_string());
-      } else {
-        state = process_static_segment(segment, nfa, state);
-        metadata.statics += 1;
-      }
-    }
-
-    nfa.acceptance(state);
-    nfa.metadata(state, metadata);
-    self.handlers.insert(state, dest);
-  }
-
-  pub fn recognize<'a>(&'a self, mut path: &str) -> Result<Match<&'a T>, String> {
-    if path.char_at(0) == '/' {
-      path = path.slice_from(1);
-    }
-
-    let nfa = &self.nfa;
-    let result = nfa.process(path, |index| nfa.get(index).metadata.get_ref());
-
-    match result {
-      Ok(nfa_match) => {
-        let mut map = Params::new();
-        let state = &nfa.get(nfa_match.state);
-        let metadata = state.metadata.get_ref();
-        let param_names = metadata.param_names.clone();
-
-        for (i, capture) in nfa_match.captures.iter().enumerate() {
-          map.insert(param_names[i].to_string(), capture.to_string());
+    pub fn add(&mut self, mut route: &str, dest: T) {
+        if route.char_at(0) == '/' {
+            route = route.slice_from(1);
         }
 
-        let handler = self.handlers.find(&nfa_match.state).unwrap();
-        Ok(Match::new(handler, map))
-      },
-      Err(str) => Err(str)
+        let nfa = &mut self.nfa;
+        let mut state = 0;
+        let mut metadata = Metadata::new();
+
+        for (i, segment) in route.split('/').enumerate() {
+            if i > 0 { state = nfa.put(state, CharacterClass::valid_char('/')); }
+
+            if segment.len() > 0 && segment.char_at(0) == ':' {
+                state = process_dynamic_segment(nfa, state);
+                metadata.dynamics += 1;
+                metadata.param_names.push(segment.slice_from(1).to_string());
+            } else if segment.len() > 0 && segment.char_at(0) == '*' {
+                state = process_star_state(nfa, state);
+                metadata.stars += 1;
+                metadata.param_names.push(segment.slice_from(1).to_string());
+            } else {
+                state = process_static_segment(segment, nfa, state);
+                metadata.statics += 1;
+            }
+        }
+
+        nfa.acceptance(state);
+        nfa.metadata(state, metadata);
+        self.handlers.insert(state, dest);
     }
-  }
+
+    pub fn recognize<'a>(&'a self, mut path: &str) -> Result<Match<&'a T>, String> {
+        if path.char_at(0) == '/' {
+            path = path.slice_from(1);
+        }
+
+        let nfa = &self.nfa;
+        let result = nfa.process(path, |index| nfa.get(index).metadata.get_ref());
+
+        match result {
+            Ok(nfa_match) => {
+                let mut map = Params::new();
+                let state = &nfa.get(nfa_match.state);
+                let metadata = state.metadata.get_ref();
+                let param_names = metadata.param_names.clone();
+
+                for (i, capture) in nfa_match.captures.iter().enumerate() {
+                    map.insert(param_names[i].to_string(), capture.to_string());
+                }
+
+                let handler = self.handlers.find(&nfa_match.state).unwrap();
+                Ok(Match::new(handler, map))
+            },
+            Err(str) => Err(str)
+        }
+    }
 }
 
 fn process_static_segment<T>(segment: &str, nfa: &mut NFA<T>, mut state: uint) -> uint {
-  for char in segment.chars() {
-    state = nfa.put(state, CharacterClass::valid_char(char));
-  }
+    for char in segment.chars() {
+        state = nfa.put(state, CharacterClass::valid_char(char));
+    }
 
-  state
+    state
 }
 
 fn process_dynamic_segment<T>(nfa: &mut NFA<T>, mut state: uint) -> uint {
-  state = nfa.put(state, CharacterClass::invalid_char('/'));
-  nfa.put_state(state, state);
-  nfa.start_capture(state);
-  nfa.end_capture(state);
+    state = nfa.put(state, CharacterClass::invalid_char('/'));
+    nfa.put_state(state, state);
+    nfa.start_capture(state);
+    nfa.end_capture(state);
 
-  state
+    state
 }
 
 fn process_star_state<T>(nfa: &mut NFA<T>, mut state: uint) -> uint {
-  state = nfa.put(state, CharacterClass::any());
-  nfa.put_state(state, state);
-  nfa.start_capture(state);
-  nfa.end_capture(state);
+    state = nfa.put(state, CharacterClass::any());
+    nfa.put_state(state, state);
+    nfa.start_capture(state);
+    nfa.end_capture(state);
 
-  state
+    state
 }
 
 #[test]
 fn basic_router() {
-  let mut router = Router::new();
+    let mut router = Router::new();
 
-  router.add("/thomas", "Thomas".to_string());
-  router.add("/tom", "Tom".to_string());
-  router.add("/wycats", "Yehuda".to_string());
+    router.add("/thomas", "Thomas".to_string());
+    router.add("/tom", "Tom".to_string());
+    router.add("/wycats", "Yehuda".to_string());
 
-  let m = router.recognize("/thomas").unwrap();
+    let m = router.recognize("/thomas").unwrap();
 
-  assert_eq!(*m.handler, "Thomas".to_string());
-  assert_eq!(m.params, Params::new());
+    assert_eq!(*m.handler, "Thomas".to_string());
+    assert_eq!(m.params, Params::new());
 }
 
 #[test]
 fn root_router() {
-  let mut router = Router::new();
-  router.add("/", 10i);
-  assert_eq!(*router.recognize("/").unwrap().handler, 10)
+    let mut router = Router::new();
+    router.add("/", 10i);
+    assert_eq!(*router.recognize("/").unwrap().handler, 10)
 }
 
 #[test]
 fn ambiguous_router() {
-  let mut router = Router::new();
+    let mut router = Router::new();
 
-  router.add("/posts/new", "new".to_string());
-  router.add("/posts/:id", "id".to_string());
+    router.add("/posts/new", "new".to_string());
+    router.add("/posts/:id", "id".to_string());
 
-  let id = router.recognize("/posts/1").unwrap();
+    let id = router.recognize("/posts/1").unwrap();
 
-  assert_eq!(*id.handler, "id".to_string());
-  assert_eq!(id.params, params("id", "1"));
+    assert_eq!(*id.handler, "id".to_string());
+    assert_eq!(id.params, params("id", "1"));
 
-  let new = router.recognize("/posts/new").unwrap();
-  assert_eq!(*new.handler, "new".to_string());
-  assert_eq!(new.params, Params::new());
+    let new = router.recognize("/posts/new").unwrap();
+    assert_eq!(*new.handler, "new".to_string());
+    assert_eq!(new.params, Params::new());
 }
-
 
 #[test]
 fn ambiguous_router_b() {
-  let mut router = Router::new();
+    let mut router = Router::new();
 
-  router.add("/posts/:id", "id".to_string());
-  router.add("/posts/new", "new".to_string());
+    router.add("/posts/:id", "id".to_string());
+    router.add("/posts/new", "new".to_string());
 
-  let id = router.recognize("/posts/1").unwrap();
+    let id = router.recognize("/posts/1").unwrap();
 
-  assert_eq!(*id.handler, "id".to_string());
-  assert_eq!(id.params, params("id", "1"));
+    assert_eq!(*id.handler, "id".to_string());
+    assert_eq!(id.params, params("id", "1"));
 
-  let new = router.recognize("/posts/new").unwrap();
-  assert_eq!(*new.handler, "new".to_string());
-  assert_eq!(new.params, Params::new());
+    let new = router.recognize("/posts/new").unwrap();
+    assert_eq!(*new.handler, "new".to_string());
+    assert_eq!(new.params, Params::new());
 }
 
 #[test]
 fn multiple_params() {
-  let mut router = Router::new();
+    let mut router = Router::new();
 
-  router.add("/posts/:post_id/comments/:id", "comment".to_string());
-  router.add("/posts/:post_id/comments", "comments".to_string());
+    router.add("/posts/:post_id/comments/:id", "comment".to_string());
+    router.add("/posts/:post_id/comments", "comments".to_string());
 
-  let com = router.recognize("/posts/12/comments/100").unwrap();
-  let coms = router.recognize("/posts/12/comments").unwrap();
+    let com = router.recognize("/posts/12/comments/100").unwrap();
+    let coms = router.recognize("/posts/12/comments").unwrap();
 
-  assert_eq!(*com.handler, "comment".to_string());
-  assert_eq!(com.params, two_params("post_id", "12", "id", "100"));
+    assert_eq!(*com.handler, "comment".to_string());
+    assert_eq!(com.params, two_params("post_id", "12", "id", "100"));
 
-  assert_eq!(*coms.handler, "comments".to_string());
-  assert_eq!(coms.params, params("post_id", "12"));
-  assert_eq!(coms.params["post_id"], "12".to_string());
+    assert_eq!(*coms.handler, "comments".to_string());
+    assert_eq!(coms.params, params("post_id", "12"));
+    assert_eq!(coms.params["post_id"], "12".to_string());
 }
 
 #[test]
 fn star() {
-  let mut router = Router::new();
+    let mut router = Router::new();
 
-  router.add("*foo", "test".to_string());
-  router.add("/bar/*foo", "test2".to_string());
+    router.add("*foo", "test".to_string());
+    router.add("/bar/*foo", "test2".to_string());
 
-  let m = router.recognize("/test").unwrap();
-  assert_eq!(*m.handler, "test".to_string());
-  assert_eq!(m.params, params("foo", "test"));
+    let m = router.recognize("/test").unwrap();
+    assert_eq!(*m.handler, "test".to_string());
+    assert_eq!(m.params, params("foo", "test"));
 
-  let m = router.recognize("/foo/bar").unwrap();
-  assert_eq!(*m.handler, "test".to_string());
-  assert_eq!(m.params, params("foo", "foo/bar"));
+    let m = router.recognize("/foo/bar").unwrap();
+    assert_eq!(*m.handler, "test".to_string());
+    assert_eq!(m.params, params("foo", "foo/bar"));
 
-  let m = router.recognize("/bar/foo").unwrap();
-  assert_eq!(*m.handler, "test".to_string());
-  assert_eq!(m.params, params("foo", "bar/foo"));
+    let m = router.recognize("/bar/foo").unwrap();
+    assert_eq!(*m.handler, "test".to_string());
+    assert_eq!(m.params, params("foo", "bar/foo"));
 }
 
 #[bench]
 fn benchmark(b: &mut test::Bencher) {
-  let mut router = Router::new();
-  router.add("/posts/:post_id/comments/:id", "comment".to_string());
-  router.add("/posts/:post_id/comments", "comments".to_string());
-  router.add("/posts/:post_id", "post".to_string());
-  router.add("/posts", "posts".to_string());
-  router.add("/comments", "comments2".to_string());
-  router.add("/comments/:id", "comment2".to_string());
+    let mut router = Router::new();
+    router.add("/posts/:post_id/comments/:id", "comment".to_string());
+    router.add("/posts/:post_id/comments", "comments".to_string());
+    router.add("/posts/:post_id", "post".to_string());
+    router.add("/posts", "posts".to_string());
+    router.add("/comments", "comments2".to_string());
+    router.add("/comments/:id", "comment2".to_string());
 
-  b.iter(|| {
-    router.recognize("/posts/100/comments/200")
-  });
+    b.iter(|| {
+        router.recognize("/posts/100/comments/200")
+    });
 }
 
 #[allow(dead_code)]
 fn params(key: &str, val: &str) -> Params {
-  let mut map = Params::new();
-  map.insert(key.to_string(), val.to_string());
-  map
+    let mut map = Params::new();
+    map.insert(key.to_string(), val.to_string());
+    map
 }
 
 #[allow(dead_code)]
 fn two_params(k1: &str, v1: &str, k2: &str, v2: &str) -> Params {
-  let mut map = Params::new();
-  map.insert(k1.to_string(), v1.to_string());
-  map.insert(k2.to_string(), v2.to_string());
-  map
+    let mut map = Params::new();
+    map.insert(k1.to_string(), v1.to_string());
+    map.insert(k2.to_string(), v2.to_string());
+    map
 }

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -6,590 +6,590 @@ use std::u64;
 
 #[deriving(PartialEq, Eq, Clone)]
 pub struct CharSet {
-  low_mask: u64,
-  high_mask: u64,
-  non_ascii: HashSet<char>
+    low_mask: u64,
+    high_mask: u64,
+    non_ascii: HashSet<char>
 }
 
 impl CharSet {
-  pub fn new() -> CharSet {
-    CharSet{ low_mask: 0, high_mask: 0, non_ascii: HashSet::new() }
-  }
-
-  pub fn insert(&mut self, char: char) {
-    let val = char as uint - 1;
-
-    if val > 127 {
-      self.non_ascii.insert(char);
-    } else if val > 63 {
-      let bit = 1 << val - 64;
-      self.high_mask = self.high_mask | bit;
-    } else {
-      let bit = 1 << val;
-      self.low_mask = self.low_mask | bit;
+    pub fn new() -> CharSet {
+        CharSet{ low_mask: 0, high_mask: 0, non_ascii: HashSet::new() }
     }
-  }
 
-  pub fn contains(&self, char: char) -> bool {
-    let val = char as uint - 1;
+    pub fn insert(&mut self, char: char) {
+        let val = char as uint - 1;
 
-    if val > 127 {
-      self.non_ascii.contains(&char)
-    } else if val > 63 {
-      let bit = 1 << val - 64;
-      self.high_mask & bit != 0
-    } else {
-      let bit = 1 << val;
-      self.low_mask & bit != 0
+        if val > 127 {
+            self.non_ascii.insert(char);
+        } else if val > 63 {
+            let bit = 1 << val - 64;
+            self.high_mask = self.high_mask | bit;
+        } else {
+            let bit = 1 << val;
+            self.low_mask = self.low_mask | bit;
+        }
     }
-  }
+
+    pub fn contains(&self, char: char) -> bool {
+        let val = char as uint - 1;
+
+        if val > 127 {
+            self.non_ascii.contains(&char)
+        } else if val > 63 {
+            let bit = 1 << val - 64;
+            self.high_mask & bit != 0
+        } else {
+            let bit = 1 << val;
+            self.low_mask & bit != 0
+        }
+    }
 }
 
 #[deriving(PartialEq, Eq, Clone)]
 pub enum CharacterClass {
-  Ascii(u64, u64, bool),
-  ValidChars(CharSet),
-  InvalidChars(CharSet)
+    Ascii(u64, u64, bool),
+    ValidChars(CharSet),
+    InvalidChars(CharSet)
 }
 
 impl CharacterClass {
-  pub fn any() -> CharacterClass {
-    Ascii(u64::MAX, u64::MAX, true)
-  }
-
-  pub fn valid(string: &str) -> CharacterClass {
-    ValidChars(CharacterClass::str_to_set(string))
-  }
-
-  pub fn invalid(string: &str) -> CharacterClass {
-    InvalidChars(CharacterClass::str_to_set(string))
-  }
-
-  pub fn valid_char(char: char) -> CharacterClass {
-    let val = char as uint - 1;
-
-    if val > 127 {
-      ValidChars(CharacterClass::char_to_set(char))
-    } else if val > 63 {
-      Ascii(1 << val - 64, 0, false)
-    } else {
-      Ascii(0, 1 << val, false)
+    pub fn any() -> CharacterClass {
+        Ascii(u64::MAX, u64::MAX, true)
     }
-  }
 
-  pub fn invalid_char(char: char) -> CharacterClass {
-    let val = char as uint - 1;
-
-    if val > 127 {
-      InvalidChars(CharacterClass::char_to_set(char))
-    } else if val > 63 {
-      Ascii(u64::MAX ^ (1 << val - 64), u64::MAX, true)
-    } else {
-      Ascii(u64::MAX, u64::MAX ^ (1 << val), true)
+    pub fn valid(string: &str) -> CharacterClass {
+        ValidChars(CharacterClass::str_to_set(string))
     }
-  }
 
+    pub fn invalid(string: &str) -> CharacterClass {
+        InvalidChars(CharacterClass::str_to_set(string))
+    }
 
-  pub fn matches(&self, char: char) -> bool {
-    match *self {
-      ValidChars(ref valid) => valid.contains(char),
-      InvalidChars(ref invalid) => !invalid.contains(char),
-      Ascii(high, low, unicode) => {
+    pub fn valid_char(char: char) -> CharacterClass {
         let val = char as uint - 1;
+
         if val > 127 {
-          unicode
+            ValidChars(CharacterClass::char_to_set(char))
         } else if val > 63 {
-          high & (1 << (val - 64)) != 0
+            Ascii(1 << val - 64, 0, false)
         } else {
-          low & (1 << val) != 0
+            Ascii(0, 1 << val, false)
         }
-      }
     }
-  }
 
-  fn char_to_set(char: char) -> CharSet {
-    let mut set = CharSet::new();
-    set.insert(char);
-    set
-  }
+    pub fn invalid_char(char: char) -> CharacterClass {
+        let val = char as uint - 1;
 
-  fn str_to_set(string: &str) -> CharSet {
-    let mut set = CharSet::new();
-    for char in string.chars() {
-      set.insert(char);
+        if val > 127 {
+            InvalidChars(CharacterClass::char_to_set(char))
+        } else if val > 63 {
+            Ascii(u64::MAX ^ (1 << val - 64), u64::MAX, true)
+        } else {
+            Ascii(u64::MAX, u64::MAX ^ (1 << val), true)
+        }
     }
-    set
-  }
+
+
+    pub fn matches(&self, char: char) -> bool {
+        match *self {
+            ValidChars(ref valid) => valid.contains(char),
+            InvalidChars(ref invalid) => !invalid.contains(char),
+            Ascii(high, low, unicode) => {
+                let val = char as uint - 1;
+                if val > 127 {
+                    unicode
+                } else if val > 63 {
+                    high & (1 << (val - 64)) != 0
+                } else {
+                    low & (1 << val) != 0
+                }
+            }
+        }
+    }
+
+    fn char_to_set(char: char) -> CharSet {
+        let mut set = CharSet::new();
+        set.insert(char);
+        set
+    }
+
+    fn str_to_set(string: &str) -> CharSet {
+        let mut set = CharSet::new();
+        for char in string.chars() {
+            set.insert(char);
+        }
+        set
+    }
 }
 
 #[deriving(Clone)]
 struct Thread {
-  state: uint,
-  captures: Vec<(uint, uint)>,
-  capture_begin: Option<uint>
+    state: uint,
+    captures: Vec<(uint, uint)>,
+    capture_begin: Option<uint>
 }
 
 impl Thread {
-  pub fn new() -> Thread {
-    Thread{ state: 0, captures: Vec::new(), capture_begin: None }
-  }
+    pub fn new() -> Thread {
+        Thread{ state: 0, captures: Vec::new(), capture_begin: None }
+    }
 
-  #[inline]
-  pub fn start_capture(&mut self, start: uint) {
-    self.capture_begin = Some(start);
-  }
+    #[inline]
+    pub fn start_capture(&mut self, start: uint) {
+        self.capture_begin = Some(start);
+    }
 
-  #[inline]
-  pub fn end_capture(&mut self, end: uint) {
-    self.captures.push((self.capture_begin.unwrap(), end));
-    self.capture_begin = None;
-  }
+    #[inline]
+    pub fn end_capture(&mut self, end: uint) {
+        self.captures.push((self.capture_begin.unwrap(), end));
+        self.capture_begin = None;
+    }
 
-  pub fn extract<'a>(&self, source: &'a str) -> Vec<&'a str> {
-    self.captures.iter().map(|&(begin, end)| source.slice(begin, end)).collect()
-  }
+    pub fn extract<'a>(&self, source: &'a str) -> Vec<&'a str> {
+        self.captures.iter().map(|&(begin, end)| source.slice(begin, end)).collect()
+    }
 }
 
 #[deriving(Clone)]
 pub struct State<T> {
-  pub index: uint,
-  pub chars: CharacterClass,
-  pub next_states: Vec<uint>,
-  pub acceptance: bool,
-  pub start_capture: bool,
-  pub end_capture: bool,
-  pub metadata: Option<T>
+    pub index: uint,
+    pub chars: CharacterClass,
+    pub next_states: Vec<uint>,
+    pub acceptance: bool,
+    pub start_capture: bool,
+    pub end_capture: bool,
+    pub metadata: Option<T>
 }
 
 impl<T> PartialEq for State<T> {
-  fn eq(&self, other: &State<T>) -> bool {
-    self.index == other.index
-  }
+    fn eq(&self, other: &State<T>) -> bool {
+        self.index == other.index
+    }
 }
 
 impl<T> State<T> {
-  pub fn new(index: uint, chars: CharacterClass) -> State<T> {
-    State{ index: index, chars: chars, next_states: Vec::new(),
-           acceptance: false, start_capture: false, end_capture: false,
-           metadata: None }
-  }
+    pub fn new(index: uint, chars: CharacterClass) -> State<T> {
+        State{ index: index, chars: chars, next_states: Vec::new(),
+        acceptance: false, start_capture: false, end_capture: false,
+        metadata: None }
+    }
 }
 
 pub struct Match<'a> {
-  pub state: uint,
-  pub captures: Vec<&'a str>,
+    pub state: uint,
+    pub captures: Vec<&'a str>,
 }
 
 impl<'a> Match<'a> {
-  pub fn new<'a>(state: uint, captures: Vec<&'a str>) -> Match<'a> {
-    Match{ state: state, captures: captures }
-  }
+    pub fn new<'a>(state: uint, captures: Vec<&'a str>) -> Match<'a> {
+        Match{ state: state, captures: captures }
+    }
 }
 
 #[deriving(Clone)]
 pub struct NFA<T> {
-  states: Vec<State<T>>,
-  start_capture: Vec<bool>,
-  end_capture: Vec<bool>,
-  acceptance: Vec<bool>,
+    states: Vec<State<T>>,
+    start_capture: Vec<bool>,
+    end_capture: Vec<bool>,
+    acceptance: Vec<bool>,
 }
 
 impl<T> NFA<T> {
-  pub fn new() -> NFA<T> {
-    let root = State::new(0, CharacterClass::any());
-    NFA{ states: vec![root], start_capture: vec![false],
-         end_capture: vec![false], acceptance: vec![false] }
-  }
-
-  pub fn process<'a, I: Ord>(&self, string: &'a str, ord: |index: uint| -> I)
-      -> Result<Match<'a>, String>
-  {
-    let mut threads = vec![Thread::new()];
-
-    for (i, char) in string.chars().enumerate() {
-      let next_threads = self.process_char(threads, char, i);
-
-      if next_threads.is_empty() {
-        return Err(format!("Couldn't process {}", string));
-      }
-
-      threads = next_threads;
+    pub fn new() -> NFA<T> {
+        let root = State::new(0, CharacterClass::any());
+        NFA{ states: vec![root], start_capture: vec![false],
+        end_capture: vec![false], acceptance: vec![false] }
     }
 
-    let mut returned = threads.move_iter().filter(|thread| {
-      self.get(thread.state).acceptance
-    });
+    pub fn process<'a, I: Ord>(&self, string: &'a str, ord: |index: uint| -> I)
+        -> Result<Match<'a>, String>
+        {
+            let mut threads = vec![Thread::new()];
 
-    let thread = returned.max_by(|thread| ord(thread.state));
+            for (i, char) in string.chars().enumerate() {
+                let next_threads = self.process_char(threads, char, i);
 
-    match thread {
-      None => Err("The string was exhausted before reaching \
+                if next_threads.is_empty() {
+                    return Err(format!("Couldn't process {}", string));
+                }
+
+                threads = next_threads;
+            }
+
+            let mut returned = threads.move_iter().filter(|thread| {
+                self.get(thread.state).acceptance
+            });
+
+            let thread = returned.max_by(|thread| ord(thread.state));
+
+            match thread {
+                None => Err("The string was exhausted before reaching \
                    an acceptance state".to_string()),
       Some(mut thread) => {
-        if thread.capture_begin.is_some() { thread.end_capture(string.len()); }
+          if thread.capture_begin.is_some() { thread.end_capture(string.len()); }
 
-        let state = self.get(thread.state);
-        Ok(Match::new(state.index, thread.extract(string)))
+          let state = self.get(thread.state);
+          Ok(Match::new(state.index, thread.extract(string)))
       }
-    }
-  }
-
-  #[inline]
-  fn process_char<'a>(&self, threads: Vec<Thread>,
-                      char: char, pos: uint) -> Vec<Thread> {
-    let mut returned = Vec::with_capacity(threads.len());
-
-    for mut thread in threads.move_iter() {
-      let current_state = self.get(thread.state);
-
-      let mut count = 0i;
-      let mut found_state = 0;
-
-      for &index in current_state.next_states.iter() {
-        let state = &self.states[index];
-
-        if state.chars.matches(char) {
-          count += 1;
-          found_state = index;
+            }
         }
-      }
 
-      if count == 1 {
-        thread.state = found_state;
-        capture(self, &mut thread, current_state.index, found_state, pos);
-        returned.push(thread);
-        continue;
-      }
+    #[inline]
+    fn process_char<'a>(&self, threads: Vec<Thread>,
+                        char: char, pos: uint) -> Vec<Thread> {
+        let mut returned = Vec::with_capacity(threads.len());
 
-      for &index in current_state.next_states.iter() {
-        let state = &self.states[index];
-        if state.chars.matches(char) {
-          let mut thread = fork_thread(&thread, state);
-          capture(self, &mut thread, current_state.index, index, pos);
-          returned.push(thread);
+        for mut thread in threads.move_iter() {
+            let current_state = self.get(thread.state);
+
+            let mut count = 0i;
+            let mut found_state = 0;
+
+            for &index in current_state.next_states.iter() {
+                let state = &self.states[index];
+
+                if state.chars.matches(char) {
+                    count += 1;
+                    found_state = index;
+                }
+            }
+
+            if count == 1 {
+                thread.state = found_state;
+                capture(self, &mut thread, current_state.index, found_state, pos);
+                returned.push(thread);
+                continue;
+            }
+
+            for &index in current_state.next_states.iter() {
+                let state = &self.states[index];
+                if state.chars.matches(char) {
+                    let mut thread = fork_thread(&thread, state);
+                    capture(self, &mut thread, current_state.index, index, pos);
+                    returned.push(thread);
+                }
+            }
+
         }
-      }
 
-    }
-
-    returned
-  }
-
-  #[inline]
-  pub fn get<'a>(&'a self, state: uint) -> &'a State<T> {
-    &self.states[state]
-  }
-
-  pub fn get_mut<'a>(&'a mut self, state: uint) -> &'a mut State<T> {
-    self.states.get_mut(state)
-  }
-
-  pub fn put(&mut self, index: uint, chars: CharacterClass) -> uint {
-    {
-      let state = self.get(index);
-
-      for &index in state.next_states.iter() {
-        let state = self.get(index);
-        if state.chars == chars {
-          return index;
-        }
-      }
+        returned
     }
 
-    let state = self.new_state(chars);
-    self.get_mut(index).next_states.push(state);
-    state
-  }
+    #[inline]
+    pub fn get<'a>(&'a self, state: uint) -> &'a State<T> {
+        &self.states[state]
+    }
 
-  pub fn put_state(&mut self, index: uint, child: uint) {
-    self.get_mut(index).next_states.push(child);
-  }
+    pub fn get_mut<'a>(&'a mut self, state: uint) -> &'a mut State<T> {
+        self.states.get_mut(state)
+    }
 
-  pub fn acceptance(&mut self, index: uint) {
-    self.get_mut(index).acceptance = true;
-    *self.acceptance.get_mut(index) = true;
-  }
+    pub fn put(&mut self, index: uint, chars: CharacterClass) -> uint {
+        {
+            let state = self.get(index);
 
-  pub fn start_capture(&mut self, index: uint) {
-    self.get_mut(index).start_capture = true;
-    *self.start_capture.get_mut(index) = true;
-  }
+            for &index in state.next_states.iter() {
+                let state = self.get(index);
+                if state.chars == chars {
+                    return index;
+                }
+            }
+        }
 
-  pub fn end_capture(&mut self, index: uint) {
-    self.get_mut(index).end_capture = true;
-    *self.end_capture.get_mut(index) = true;
-  }
+        let state = self.new_state(chars);
+        self.get_mut(index).next_states.push(state);
+        state
+    }
 
-  pub fn metadata(&mut self, index: uint, metadata: T) {
-    self.get_mut(index).metadata = Some(metadata);
-  }
+    pub fn put_state(&mut self, index: uint, child: uint) {
+        self.get_mut(index).next_states.push(child);
+    }
 
-  fn new_state(&mut self, chars: CharacterClass) -> uint {
-    let index = self.states.len();
-    let state = State::new(index, chars);
-    self.states.push(state);
+    pub fn acceptance(&mut self, index: uint) {
+        self.get_mut(index).acceptance = true;
+        *self.acceptance.get_mut(index) = true;
+    }
 
-    self.acceptance.push(false);
-    self.start_capture.push(false);
-    self.end_capture.push(false);
+    pub fn start_capture(&mut self, index: uint) {
+        self.get_mut(index).start_capture = true;
+        *self.start_capture.get_mut(index) = true;
+    }
 
-    index
-  }
+    pub fn end_capture(&mut self, index: uint) {
+        self.get_mut(index).end_capture = true;
+        *self.end_capture.get_mut(index) = true;
+    }
+
+    pub fn metadata(&mut self, index: uint, metadata: T) {
+        self.get_mut(index).metadata = Some(metadata);
+    }
+
+    fn new_state(&mut self, chars: CharacterClass) -> uint {
+        let index = self.states.len();
+        let state = State::new(index, chars);
+        self.states.push(state);
+
+        self.acceptance.push(false);
+        self.start_capture.push(false);
+        self.end_capture.push(false);
+
+        index
+    }
 }
 
 #[inline]
 fn fork_thread<T>(thread: &Thread, state: &State<T>) -> Thread {
-  let mut new_trace = thread.clone();
-  new_trace.state = state.index;
-  new_trace
+    let mut new_trace = thread.clone();
+    new_trace.state = state.index;
+    new_trace
 }
 
 #[inline]
 fn capture<T>(nfa: &NFA<T>, thread: &mut Thread, current_state: uint, next_state: uint, pos: uint) {
-  if thread.capture_begin == None && nfa.start_capture[next_state] {
-    thread.start_capture(pos);
-  }
+    if thread.capture_begin == None && nfa.start_capture[next_state] {
+        thread.start_capture(pos);
+    }
 
-  if thread.capture_begin != None && nfa.end_capture[current_state] &&
-     next_state > current_state {
-    thread.end_capture(pos);
-  }
+    if thread.capture_begin != None && nfa.end_capture[current_state] &&
+        next_state > current_state {
+            thread.end_capture(pos);
+        }
 }
 
 #[test]
 fn basic_test() {
-  let mut nfa = NFA::<()>::new();
-  let a = nfa.put(0, CharacterClass::valid("h"));
-  let b = nfa.put(a, CharacterClass::valid("e"));
-  let c = nfa.put(b, CharacterClass::valid("l"));
-  let d = nfa.put(c, CharacterClass::valid("l"));
-  let e = nfa.put(d, CharacterClass::valid("o"));
-  nfa.acceptance(e);
+    let mut nfa = NFA::<()>::new();
+    let a = nfa.put(0, CharacterClass::valid("h"));
+    let b = nfa.put(a, CharacterClass::valid("e"));
+    let c = nfa.put(b, CharacterClass::valid("l"));
+    let d = nfa.put(c, CharacterClass::valid("l"));
+    let e = nfa.put(d, CharacterClass::valid("o"));
+    nfa.acceptance(e);
 
-  let m = nfa.process("hello", |a| a);
+    let m = nfa.process("hello", |a| a);
 
-  assert!(m.unwrap().state == e, "You didn't get the right final state");
+    assert!(m.unwrap().state == e, "You didn't get the right final state");
 }
 
 #[test]
 fn multiple_solutions() {
-  let mut nfa = NFA::<()>::new();
-  let a1 = nfa.put(0, CharacterClass::valid("n"));
-  let b1 = nfa.put(a1, CharacterClass::valid("e"));
-  let c1 = nfa.put(b1, CharacterClass::valid("w"));
-  nfa.acceptance(c1);
+    let mut nfa = NFA::<()>::new();
+    let a1 = nfa.put(0, CharacterClass::valid("n"));
+    let b1 = nfa.put(a1, CharacterClass::valid("e"));
+    let c1 = nfa.put(b1, CharacterClass::valid("w"));
+    nfa.acceptance(c1);
 
-  let a2 = nfa.put(0, CharacterClass::invalid(""));
-  let b2 = nfa.put(a2, CharacterClass::invalid(""));
-  let c2 = nfa.put(b2, CharacterClass::invalid(""));
-  nfa.acceptance(c2);
+    let a2 = nfa.put(0, CharacterClass::invalid(""));
+    let b2 = nfa.put(a2, CharacterClass::invalid(""));
+    let c2 = nfa.put(b2, CharacterClass::invalid(""));
+    nfa.acceptance(c2);
 
-  let m = nfa.process("new", |a| a);
+    let m = nfa.process("new", |a| a);
 
-  assert!(m.unwrap().state == c2, "The two states were not found");
+    assert!(m.unwrap().state == c2, "The two states were not found");
 }
 
 #[test]
 fn multiple_paths() {
-  let mut nfa = NFA::<()>::new();
-  let a = nfa.put(0, CharacterClass::valid("t"));   // t
-  let b1 = nfa.put(a, CharacterClass::valid("h"));  // th
-  let c1 = nfa.put(b1, CharacterClass::valid("o")); // tho
-  let d1 = nfa.put(c1, CharacterClass::valid("m")); // thom
-  let e1 = nfa.put(d1, CharacterClass::valid("a")); // thoma
-  let f1 = nfa.put(e1, CharacterClass::valid("s")); // thomas
+    let mut nfa = NFA::<()>::new();
+    let a = nfa.put(0, CharacterClass::valid("t"));   // t
+    let b1 = nfa.put(a, CharacterClass::valid("h"));  // th
+    let c1 = nfa.put(b1, CharacterClass::valid("o")); // tho
+    let d1 = nfa.put(c1, CharacterClass::valid("m")); // thom
+    let e1 = nfa.put(d1, CharacterClass::valid("a")); // thoma
+    let f1 = nfa.put(e1, CharacterClass::valid("s")); // thomas
 
-  let b2 = nfa.put(a, CharacterClass::valid("o"));  // to
-  let c2 = nfa.put(b2, CharacterClass::valid("m")); // tom
+    let b2 = nfa.put(a, CharacterClass::valid("o"));  // to
+    let c2 = nfa.put(b2, CharacterClass::valid("m")); // tom
 
-  nfa.acceptance(f1);
-  nfa.acceptance(c2);
+    nfa.acceptance(f1);
+    nfa.acceptance(c2);
 
-  let thomas = nfa.process("thomas", |a| a);
-  let tom = nfa.process("tom", |a| a);
-  let thom = nfa.process("thom", |a| a);
-  let nope = nfa.process("nope", |a| a);
+    let thomas = nfa.process("thomas", |a| a);
+    let tom = nfa.process("tom", |a| a);
+    let thom = nfa.process("thom", |a| a);
+    let nope = nfa.process("nope", |a| a);
 
-  assert!(thomas.unwrap().state == f1, "thomas was parsed correctly");
-  assert!(tom.unwrap().state == c2, "tom was parsed correctly");
-  assert!(thom.is_err(), "thom didn't reach an acceptance state");
-  assert!(nope.is_err(), "nope wasn't parsed");
+    assert!(thomas.unwrap().state == f1, "thomas was parsed correctly");
+    assert!(tom.unwrap().state == c2, "tom was parsed correctly");
+    assert!(thom.is_err(), "thom didn't reach an acceptance state");
+    assert!(nope.is_err(), "nope wasn't parsed");
 }
 
 #[test]
 fn repetitions() {
-  let mut nfa = NFA::<()>::new();
-  let a = nfa.put(0, CharacterClass::valid("p"));   // p
-  let b = nfa.put(a, CharacterClass::valid("o"));   // po
-  let c = nfa.put(b, CharacterClass::valid("s"));   // pos
-  let d = nfa.put(c, CharacterClass::valid("t"));   // post
-  let e = nfa.put(d, CharacterClass::valid("s"));   // posts
-  let f = nfa.put(e, CharacterClass::valid("/"));   // posts/
-  let g = nfa.put(f, CharacterClass::invalid("/")); // posts/[^/]
-  nfa.put_state(g, g);
+    let mut nfa = NFA::<()>::new();
+    let a = nfa.put(0, CharacterClass::valid("p"));   // p
+    let b = nfa.put(a, CharacterClass::valid("o"));   // po
+    let c = nfa.put(b, CharacterClass::valid("s"));   // pos
+    let d = nfa.put(c, CharacterClass::valid("t"));   // post
+    let e = nfa.put(d, CharacterClass::valid("s"));   // posts
+    let f = nfa.put(e, CharacterClass::valid("/"));   // posts/
+    let g = nfa.put(f, CharacterClass::invalid("/")); // posts/[^/]
+    nfa.put_state(g, g);
 
-  nfa.acceptance(g);
+    nfa.acceptance(g);
 
-  let post = nfa.process("posts/1", |a| a);
-  let new_post = nfa.process("posts/new", |a| a);
-  let invalid = nfa.process("posts/", |a| a);
+    let post = nfa.process("posts/1", |a| a);
+    let new_post = nfa.process("posts/new", |a| a);
+    let invalid = nfa.process("posts/", |a| a);
 
-  assert!(post.unwrap().state == g, "posts/1 was parsed");
-  assert!(new_post.unwrap().state == g, "posts/new was parsed");
-  assert!(invalid.is_err(), "posts/ was invalid");
+    assert!(post.unwrap().state == g, "posts/1 was parsed");
+    assert!(new_post.unwrap().state == g, "posts/new was parsed");
+    assert!(invalid.is_err(), "posts/ was invalid");
 }
 
 #[test]
 fn repetitions_with_ambiguous() {
-  let mut nfa = NFA::<()>::new();
-  let a  = nfa.put(0, CharacterClass::valid("p"));   // p
-  let b  = nfa.put(a, CharacterClass::valid("o"));   // po
-  let c  = nfa.put(b, CharacterClass::valid("s"));   // pos
-  let d  = nfa.put(c, CharacterClass::valid("t"));   // post
-  let e  = nfa.put(d, CharacterClass::valid("s"));   // posts
-  let f  = nfa.put(e, CharacterClass::valid("/"));   // posts/
-  let g1 = nfa.put(f, CharacterClass::invalid("/")); // posts/[^/]
-  let g2 = nfa.put(f, CharacterClass::valid("n"));   // posts/n
-  let h2 = nfa.put(g2, CharacterClass::valid("e"));  // posts/ne
-  let i2 = nfa.put(h2, CharacterClass::valid("w"));  // posts/new
+    let mut nfa = NFA::<()>::new();
+    let a  = nfa.put(0, CharacterClass::valid("p"));   // p
+    let b  = nfa.put(a, CharacterClass::valid("o"));   // po
+    let c  = nfa.put(b, CharacterClass::valid("s"));   // pos
+    let d  = nfa.put(c, CharacterClass::valid("t"));   // post
+    let e  = nfa.put(d, CharacterClass::valid("s"));   // posts
+    let f  = nfa.put(e, CharacterClass::valid("/"));   // posts/
+    let g1 = nfa.put(f, CharacterClass::invalid("/")); // posts/[^/]
+    let g2 = nfa.put(f, CharacterClass::valid("n"));   // posts/n
+    let h2 = nfa.put(g2, CharacterClass::valid("e"));  // posts/ne
+    let i2 = nfa.put(h2, CharacterClass::valid("w"));  // posts/new
 
-  nfa.put_state(g1, g1);
+    nfa.put_state(g1, g1);
 
-  nfa.acceptance(g1);
-  nfa.acceptance(i2);
+    nfa.acceptance(g1);
+    nfa.acceptance(i2);
 
-  let post = nfa.process("posts/1", |a| a);
-  let ambiguous = nfa.process("posts/new", |a| a);
-  let invalid = nfa.process("posts/", |a| a);
+    let post = nfa.process("posts/1", |a| a);
+    let ambiguous = nfa.process("posts/new", |a| a);
+    let invalid = nfa.process("posts/", |a| a);
 
-  assert!(post.unwrap().state == g1, "posts/1 was parsed");
-  assert!(ambiguous.unwrap().state == i2, "posts/new was ambiguous");
-  assert!(invalid.is_err(), "posts/ was invalid");
+    assert!(post.unwrap().state == g1, "posts/1 was parsed");
+    assert!(ambiguous.unwrap().state == i2, "posts/new was ambiguous");
+    assert!(invalid.is_err(), "posts/ was invalid");
 }
 
 #[test]
 fn captures() {
-  let mut nfa = NFA::<()>::new();
-  let a = nfa.put(0, CharacterClass::valid("n"));
-  let b = nfa.put(a, CharacterClass::valid("e"));
-  let c = nfa.put(b, CharacterClass::valid("w"));
+    let mut nfa = NFA::<()>::new();
+    let a = nfa.put(0, CharacterClass::valid("n"));
+    let b = nfa.put(a, CharacterClass::valid("e"));
+    let c = nfa.put(b, CharacterClass::valid("w"));
 
-  nfa.acceptance(c);
-  nfa.start_capture(a);
-  nfa.end_capture(c);
+    nfa.acceptance(c);
+    nfa.start_capture(a);
+    nfa.end_capture(c);
 
-  let post = nfa.process("new", |a| a);
+    let post = nfa.process("new", |a| a);
 
-  assert_eq!(post.unwrap().captures, vec!["new"]);
+    assert_eq!(post.unwrap().captures, vec!["new"]);
 }
 
 #[test]
 fn capture_mid_match() {
-  let mut nfa = NFA::<()>::new();
-  let a = nfa.put(0, valid('p'));
-  let b = nfa.put(a, valid('/'));
-  let c = nfa.put(b, invalid('/'));
-  let d = nfa.put(c, valid('/'));
-  let e = nfa.put(d, valid('c'));
+    let mut nfa = NFA::<()>::new();
+    let a = nfa.put(0, valid('p'));
+    let b = nfa.put(a, valid('/'));
+    let c = nfa.put(b, invalid('/'));
+    let d = nfa.put(c, valid('/'));
+    let e = nfa.put(d, valid('c'));
 
-  nfa.put_state(c, c);
-  nfa.acceptance(e);
-  nfa.start_capture(c);
-  nfa.end_capture(c);
+    nfa.put_state(c, c);
+    nfa.acceptance(e);
+    nfa.start_capture(c);
+    nfa.end_capture(c);
 
-  let post = nfa.process("p/123/c", |a| a);
+    let post = nfa.process("p/123/c", |a| a);
 
-  assert_eq!(post.unwrap().captures, vec!["123"]);
+    assert_eq!(post.unwrap().captures, vec!["123"]);
 }
 
 #[test]
 fn capture_multiple_captures() {
-  let mut nfa = NFA::<()>::new();
-  let a = nfa.put(0, valid('p'));
-  let b = nfa.put(a, valid('/'));
-  let c = nfa.put(b, invalid('/'));
-  let d = nfa.put(c, valid('/'));
-  let e = nfa.put(d, valid('c'));
-  let f = nfa.put(e, valid('/'));
-  let g = nfa.put(f, invalid('/'));
+    let mut nfa = NFA::<()>::new();
+    let a = nfa.put(0, valid('p'));
+    let b = nfa.put(a, valid('/'));
+    let c = nfa.put(b, invalid('/'));
+    let d = nfa.put(c, valid('/'));
+    let e = nfa.put(d, valid('c'));
+    let f = nfa.put(e, valid('/'));
+    let g = nfa.put(f, invalid('/'));
 
-  nfa.put_state(c, c);
-  nfa.put_state(g, g);
-  nfa.acceptance(g);
+    nfa.put_state(c, c);
+    nfa.put_state(g, g);
+    nfa.acceptance(g);
 
-  nfa.start_capture(c);
-  nfa.end_capture(c);
+    nfa.start_capture(c);
+    nfa.end_capture(c);
 
-  nfa.start_capture(g);
-  nfa.end_capture(g);
+    nfa.start_capture(g);
+    nfa.end_capture(g);
 
-  let post = nfa.process("p/123/c/456", |a| a);
-  assert_eq!(post.unwrap().captures, vec!["123", "456"]);
+    let post = nfa.process("p/123/c/456", |a| a);
+    assert_eq!(post.unwrap().captures, vec!["123", "456"]);
 }
 
 #[test]
 fn test_ascii_set() {
-  let mut set = CharSet::new();
-  set.insert('?');
-  set.insert('a');
-  set.insert('é');
+    let mut set = CharSet::new();
+    set.insert('?');
+    set.insert('a');
+    set.insert('é');
 
-  assert!(set.contains('?'), "The set contains char 63");
-  assert!(set.contains('a'), "The set contains char 97");
-  assert!(set.contains('é'), "The set contains char 233");
-  assert!(!set.contains('q'), "The set does not contain q");
-  assert!(!set.contains('ü'), "The set does not contain ü");
+    assert!(set.contains('?'), "The set contains char 63");
+    assert!(set.contains('a'), "The set contains char 97");
+    assert!(set.contains('é'), "The set contains char 233");
+    assert!(!set.contains('q'), "The set does not contain q");
+    assert!(!set.contains('ü'), "The set does not contain ü");
 }
 
 #[bench]
 fn bench_char_set(b: &mut test::Bencher) {
-  let mut set = CharSet::new();
-  set.insert('p');
-  set.insert('n');
-  set.insert('/');
+    let mut set = CharSet::new();
+    set.insert('p');
+    set.insert('n');
+    set.insert('/');
 
-  b.iter(|| {
-    assert!(set.contains('p'))
-    assert!(set.contains('/'));
+    b.iter(|| {
+        assert!(set.contains('p'))
+        assert!(set.contains('/'));
     assert!(!set.contains('z'));
-  });
+    });
 }
 
 #[bench]
 fn bench_hash_set(b: &mut test::Bencher) {
-  let mut set = HashSet::new();
-  set.insert('p');
-  set.insert('n');
-  set.insert('/');
+    let mut set = HashSet::new();
+    set.insert('p');
+    set.insert('n');
+    set.insert('/');
 
-  b.iter(|| {
-    assert!(set.contains(&'p'));
-    assert!(set.contains(&'/'));
-    assert!(!set.contains(&'z'));
-  });
+    b.iter(|| {
+        assert!(set.contains(&'p'));
+        assert!(set.contains(&'/'));
+        assert!(!set.contains(&'z'));
+    });
 }
 
 #[bench]
 fn bench_tree_set(b: &mut test::Bencher) {
-  let mut set = TreeSet::new();
-  set.insert('p');
-  set.insert('n');
-  set.insert('/');
+    let mut set = TreeSet::new();
+    set.insert('p');
+    set.insert('n');
+    set.insert('/');
 
-  b.iter(|| {
-    assert!(set.contains(&'p'));
-    assert!(set.contains(&'/'));
-    assert!(!set.contains(&'z'));
-  });
+    b.iter(|| {
+        assert!(set.contains(&'p'));
+        assert!(set.contains(&'/'));
+        assert!(!set.contains(&'z'));
+    });
 }
 
 #[allow(dead_code)]
 fn valid(char: char) -> CharacterClass {
-  CharacterClass::valid_char(char)
+    CharacterClass::valid_char(char)
 }
 
 #[allow(dead_code)]
 fn invalid(char: char) -> CharacterClass {
-  CharacterClass::invalid_char(char)
+    CharacterClass::invalid_char(char)
 }
 


### PR DESCRIPTION
Four spaces is rust style. This is annoying, I know, but it's better to do it
early (now) then much later.

This will need to be rebased after the other PRs are merged.
