### PR TITLE
Fix enum namespace-edness

### DIFF
--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::u64;
+use self::CharacterClass::{Ascii, ValidChars, InvalidChars};
 
 #[cfg(test)] use test;
 #[cfg(test)] use std::collections::TreeSet;


### PR DESCRIPTION
Update to newest rustc where enum variants are now namespaced under their type.
