### PR TITLE
Fix char boundary bug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,4 +571,15 @@ mod tests {
             "Hello"
         );
     }
+
+    #[test]
+    fn test_chinese() {
+        let mut router = Router::new();
+        router.add("/crates/:foo/:bar", "Hello".to_string());
+
+        let m = router.recognize("/crates/实打实打算/d's'd").unwrap();
+        assert_eq!(m.handler().as_str(), "Hello");
+        assert_eq!(m.params().find("foo"), Some("实打实打算"));
+        assert_eq!(m.params().find("bar"), Some("d's'd"));
+    }
 }

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -227,7 +227,7 @@ impl<T> NFA<T> {
     {
         let mut threads = vec![Thread::new()];
 
-        for (i, char) in string.chars().enumerate() {
+        for (i, char) in string.char_indices() {
             let next_threads = self.process_char(threads, char, i);
 
             if next_threads.is_empty() {


### PR DESCRIPTION
This resolves #51 by relying on the `char_indices()` method instead of using `chars().enumerate()`. https://doc.rust-lang.org/stable/std/primitive.str.html#method.char_indices explains this in more detail.

Related:
- https://github.com/rust-lang/crates.io/issues/4052

/cc @jbr @yoshuawuyts 