### PR TITLE
add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,10 @@ edition = "2018"
 
 version = "0.3.1"
 authors = ["wycats", "rustasync"]
+
+[features]
+default = ["std"]
+std = []
+
+[dependencies]
+cfg-if = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,10 +43,20 @@
 #![doc(test(attr(allow(unused_extern_crates, unused_variables))))]
 #![doc(html_favicon_url = "https://yoshuawuyts.com/assets/http-rs/favicon.ico")]
 #![doc(html_logo_url = "https://yoshuawuyts.com/assets/http-rs/logo-rounded.png")]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-use std::cmp::Ordering;
-use std::collections::{btree_map, BTreeMap};
-use std::ops::Index;
+#![cfg_attr(not(feature = "std"), macro_use)]
+extern crate alloc;
+
+use core::cmp::Ordering;
+use alloc::collections::{btree_map, BTreeMap};
+use core::ops::Index;
+
+#[cfg(not(feature = "std"))]
+use alloc::{
+    vec::Vec, vec,
+    string::{String, ToString}
+};
 
 use crate::nfa::{CharacterClass, NFA};
 
@@ -348,6 +358,12 @@ fn process_star_state<T>(nfa: &mut NFA<T>, mut state: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::{
+        vec::Vec, 
+        string::{String, ToString}
+    };    
+
     use super::{Params, Router};
 
     #[test]

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -1,4 +1,10 @@
-use std::collections::HashSet;
+use alloc::collections::BTreeSet;
+
+#[cfg(not(feature = "std"))]
+use alloc::{
+    vec::Vec, vec, format,
+    string::{String, ToString}
+};
 
 use self::CharacterClass::{Ascii, InvalidChars, ValidChars};
 
@@ -6,7 +12,7 @@ use self::CharacterClass::{Ascii, InvalidChars, ValidChars};
 pub struct CharSet {
     low_mask: u64,
     high_mask: u64,
-    non_ascii: HashSet<char>,
+    non_ascii: BTreeSet<char>,
 }
 
 impl CharSet {
@@ -14,7 +20,7 @@ impl CharSet {
         Self {
             low_mask: 0,
             high_mask: 0,
-            non_ascii: HashSet::new(),
+            non_ascii: BTreeSet::new(),
         }
     }
 
@@ -401,6 +407,9 @@ fn capture<T>(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
+
     use super::{CharSet, CharacterClass, NFA};
 
     #[test]


### PR DESCRIPTION
Note that HashSet is being swapped with BTreeSet, since hash set is not included in `alloc` (but [`hashbrown`](https://docs.rs/hashbrown/latest/hashbrown/hash_set/struct.HashSet.html))